### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
+++ b/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
@@ -34,7 +34,7 @@ public class ChatHttpClient extends ChatClient {
                 channel = initConnection();
             } catch (InterruptedException e) {
                 e.printStackTrace();
-		Thread.currentThread().interrupt();
+				Thread.currentThread().interrupt();
             }
         }
 

--- a/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
+++ b/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
@@ -34,7 +34,7 @@ public class ChatHttpClient extends ChatClient {
                 channel = initConnection();
             } catch (InterruptedException e) {
                 e.printStackTrace();
-				Thread.currentThread().interrupt();
+		Thread.currentThread().interrupt();
             }
         }
 

--- a/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
+++ b/goodskill-chat-provider/src/main/java/com/goodskill/chat/client/http/ChatHttpClient.java
@@ -34,6 +34,7 @@ public class ChatHttpClient extends ChatClient {
                 channel = initConnection();
             } catch (InterruptedException e) {
                 e.printStackTrace();
+		Thread.currentThread().interrupt();
             }
         }
 


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).