### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/goodsKill-common/src/main/java/com/goodskill/common/JwtUtils.java
+++ b/goodsKill-common/src/main/java/com/goodskill/common/JwtUtils.java
@@ -1,4 +1,8 @@
 package com.goodskill.common;
+import MalformedJwtException;
+import ExpiredJwtException;
+import Jwts;
+import UnsupportedJwtException;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
@@ -23,7 +27,7 @@ public class JwtUtils {
     /**
      * 过期时间（毫秒单位）
      */
-    private final static long TOKEN_EXPIRE_MILLIS = 1000 * 60 * 60 * 24;
+    private final static long TOKEN_EXPIRE_MILLIS = ((1000l * 60) * 60) * 24;
 
     /**
      * 创建token


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).