### PR TITLE
[升级]Seata Server升至2.0.0并默认启用seata

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,7 +125,7 @@ ns         %     Task name
 |===
 |镜像 |版本 |端口 |用户名密码
 
-|Nacos |2.3.2-slim |8848 |nacos:nacos
+|Nacos |2.3.2-slim |8848 |nacos:nacos（控制台）
 |Redis |latest |6379 |密码:123456
 |Kafka |3.1.1 |9092 |无
 |KafkaManager |latest |9001:9000 |无
@@ -136,6 +136,7 @@ ns         %     Task name
 |Kibana |7.17.3 |5601 |无
 |RabbitMQ |latest |5672 15672 |无
 |MinIO |latest |9000 |root:password
+|Seata |2.0.0 |7091 8091|seata:seata（控制台）
 |===
 
 == 🎯 快速开始
@@ -148,7 +149,7 @@ ns         %     Task name
   mvn clean install -DskipTests
 ----
 
-* 默认端口启动nacos、redis、mysql、rabbitmq、kafka、zookeeper、elasticsearch，或者使用docker-compose{empty}footnote:[需要安装docker-desktop https://www.docker.com/products/docker-desktop/]命令：
+* 默认端口启动nacos、redis、mysql、rabbitmq、kafka、zookeeper、elasticsearch、seataServer，或者使用docker-compose{empty}footnote:[需要安装docker-desktop https://www.docker.com/products/docker-desktop/]命令：
 +
 [source,bash]
 ----

--- a/doc/docker/seata/resources/application.yml
+++ b/doc/docker/seata/resources/application.yml
@@ -48,7 +48,7 @@ seata:
   #  server:
   #    service-port: 8091 #If not configured, the default is '${server.port} + 1000'
   security:
-    secretKey: SeataSecretKey0c382ef121d778043159209298fd40bf3850a017
+    secretKey: SecretKey012345678901234567890123456789012345678901234567890123456789
     tokenValidityInMilliseconds: 1800000
     ignore:
       urls: /,/**/*.css,/**/*.js,/**/*.html,/**/*.map,/**/*.svg,/**/*.png,/**/*.ico,/console-fe/public/**,/api/v1/auth/login

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,16 +209,19 @@ services:
 #      MONGO_INITDB_ROOT_PASSWORD: root
 
   seata-server:
-    image: seataio/seata-server:1.7.0
+    image: seataio/seata-server:2.0.0
     container_name: seata-server
     hostname: seata-server
     ports:
       - "8091:8091"
       - "7091:7091"
     environment:
+      # 注册到nacos上的ip。客户端将通过该ip访问seata服务。
+      # 注意公网ip和内网ip的差异。
       - SEATA_IP=192.168.0.103
       - SEATA_PORT=8091
-      - STORE_MODE=db
+    #      - STORE_MODE=db
+    #      - SEATA_CONFIG_NAME=file:/root/seata-config/registry.conf
     volumes:
       - ./doc/docker/seata/resources/application.yml:/seata-server/resources/application.yml
     networks:

--- a/goodskill-seata/README.md
+++ b/goodskill-seata/README.md
@@ -25,6 +25,7 @@
   store.db.branchTable=branch_table
   # 全局锁表名 默认lock_table
   store.db.lockTable=lock_table
+  store.db.distributedLockTable=distributed_lock
   # 查询全局事务一次的最大条数 默认100
   store.db.queryLimit=100
   
@@ -53,6 +54,7 @@
   docker-compose up -d seata-server
   ```
   **注意**:修改environment SEATA_IP ，不配置则默认使用容器ip，会导致服务连不上seata server
+- 参考官方建表语句初始化seata_server数据库
 - 在nacos控制台中增加以下配置（group需配置为SEATA_GROUP，dataId为对应key，配置文件内容为value）
   ```
   service.vgroupMapping.my_test_tx_group=default

--- a/goodskill-seata/src/main/java/com/goodskill/seata/GoodskillSeataApplication.java
+++ b/goodskill-seata/src/main/java/com/goodskill/seata/GoodskillSeataApplication.java
@@ -4,6 +4,7 @@ import com.goodskill.api.service.GoodsService;
 import com.goodskill.api.service.SeckillService;
 import com.goodskill.api.vo.GoodsVO;
 import com.goodskill.api.vo.SeckillVO;
+import io.seata.spring.annotation.GlobalTransactional;
 import org.apache.dubbo.config.annotation.DubboReference;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,7 +23,7 @@ public class GoodskillSeataApplication {
      * 测试seata分布式事务
      */
     @GetMapping("/test")
-//    @GlobalTransactional
+    @GlobalTransactional
     public void testGlobalTransaction() {
         GoodsVO goods = new GoodsVO();
         goods.setName("test");

--- a/goodskill-seata/src/main/resources/application.yml
+++ b/goodskill-seata/src/main/resources/application.yml
@@ -27,7 +27,7 @@ dubbo:
     qos-port: 22223
 
 seata:
-  enabled: false
+  enabled: true
   #1.4.2使用此配置禁用seata
   enable-auto-data-source-proxy: true
   application-id: goodskill-seata

--- a/goodskill-seckill-provider/goodskill-service/src/main/resources/application.yml
+++ b/goodskill-seckill-provider/goodskill-service/src/main/resources/application.yml
@@ -115,9 +115,9 @@ dubbo:
     qos-port: 22222
 
 seata:
-  enabled: false
+  enabled: true
   #1.4.2使用此配置禁用seata数据源代理
-  enable-auto-data-source-proxy: false
+  enable-auto-data-source-proxy: true
   application-id: goodskill-service-provider
   tx-service-group: my_test_tx_group
   config:

--- a/goodskill-simple.yml
+++ b/goodskill-simple.yml
@@ -142,20 +142,21 @@ services:
   #      MONGO_INITDB_ROOT_PASSWORD: root
 
   seata-server:
-    image: seataio/seata-server:1.6.1
+    image: seataio/seata-server:2.0.0
     container_name: seata-server
     hostname: seata-server
     ports:
       - "8091:8091"
+      - "7091:7091"
     environment:
       # 注册到nacos上的ip。客户端将通过该ip访问seata服务。
       # 注意公网ip和内网ip的差异。
-      - SEATA_IP=192.168.2.134
+      - SEATA_IP=192.168.0.103
       - SEATA_PORT=8091
-      - STORE_MODE=file
-      - SEATA_CONFIG_NAME=file:/root/seata-config/registry.conf
+#      - STORE_MODE=db
+#      - SEATA_CONFIG_NAME=file:/root/seata-config/registry.conf
     volumes:
-      - ./doc/docker/seata/config:/root/seata-config
+      - ./doc/docker/seata/resources/application.yml:/seata-server/resources/application.yml
     networks:
       - somenetwork
 

--- a/goodskill-web/src/main/sql/seata_server.sql
+++ b/goodskill-web/src/main/sql/seata_server.sql
@@ -1,0 +1,76 @@
+create schema seata_server collate utf8mb4_0900_ai_ci;
+use seata_server;
+
+-- -------------------------------- The script used when storeMode is 'db' --------------------------------
+-- the table to store GlobalSession data
+CREATE TABLE IF NOT EXISTS `global_table`
+(
+    `xid`                       VARCHAR(128) NOT NULL,
+    `transaction_id`            BIGINT,
+    `status`                    TINYINT      NOT NULL,
+    `application_id`            VARCHAR(32),
+    `transaction_service_group` VARCHAR(32),
+    `transaction_name`          VARCHAR(128),
+    `timeout`                   INT,
+    `begin_time`                BIGINT,
+    `application_data`          VARCHAR(2000),
+    `gmt_create`                DATETIME,
+    `gmt_modified`              DATETIME,
+    PRIMARY KEY (`xid`),
+    KEY `idx_status_gmt_modified` (`status` , `gmt_modified`),
+    KEY `idx_transaction_id` (`transaction_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- the table to store BranchSession data
+CREATE TABLE IF NOT EXISTS `branch_table`
+(
+    `branch_id`         BIGINT       NOT NULL,
+    `xid`               VARCHAR(128) NOT NULL,
+    `transaction_id`    BIGINT,
+    `resource_group_id` VARCHAR(32),
+    `resource_id`       VARCHAR(256),
+    `branch_type`       VARCHAR(8),
+    `status`            TINYINT,
+    `client_id`         VARCHAR(64),
+    `application_data`  VARCHAR(2000),
+    `gmt_create`        DATETIME(6),
+    `gmt_modified`      DATETIME(6),
+    PRIMARY KEY (`branch_id`),
+    KEY `idx_xid` (`xid`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+-- the table to store lock data
+CREATE TABLE IF NOT EXISTS `lock_table`
+(
+    `row_key`        VARCHAR(128) NOT NULL,
+    `xid`            VARCHAR(128),
+    `transaction_id` BIGINT,
+    `branch_id`      BIGINT       NOT NULL,
+    `resource_id`    VARCHAR(256),
+    `table_name`     VARCHAR(32),
+    `pk`             VARCHAR(36),
+    `status`         TINYINT      NOT NULL DEFAULT '0' COMMENT '0:locked ,1:rollbacking',
+    `gmt_create`     DATETIME,
+    `gmt_modified`   DATETIME,
+    PRIMARY KEY (`row_key`),
+    KEY `idx_status` (`status`),
+    KEY `idx_branch_id` (`branch_id`),
+    KEY `idx_xid` (`xid`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `distributed_lock`
+(
+    `lock_key`       CHAR(20) NOT NULL,
+    `lock_value`     VARCHAR(20) NOT NULL,
+    `expire`         BIGINT,
+    primary key (`lock_key`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('AsyncCommitting', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('RetryCommitting', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('RetryRollbacking', ' ', 0);
+INSERT INTO `distributed_lock` (lock_key, lock_value, expire) VALUES ('TxTimeoutCheck', ' ', 0);


### PR DESCRIPTION
- 更新seata-server镜像至2.0.0版本。
- 修改相关配置以适配新版本。
- 应用全局事务注解并启用seata功能。
- 增加初始化seata_server数据库脚本。
- 在docker-compose中添加seata-server服务并启动。